### PR TITLE
retry with expected sequence token

### DIFF
--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -111,7 +111,16 @@ module Fluent
       end
 
       unless chunk.empty?
-        put_events(group_name, chunk)
+        begin
+          put_events(group_name, chunk)
+        rescue Aws::CloudWatchLogs::Errors::InvalidSequenceTokenException => e
+          e.message =~ /expected sequenceToken is: (\w+)/
+          sequence_token = $1
+          raise e unless sequence_token
+          log.warn "Retry with expected sequenceToken: #{sequence_token}"
+          store_next_sequence_token(group_name, @log_stream_name, sequence_token)
+          put_events(group_name, chunk)
+        end
       end
     end
 


### PR DESCRIPTION
Hello,

Sometime I had this kind of exception continuously:

```
2015-01-15 10:37:06 +0000 [warn]: fluent/output.rb:353:rescue in try_flush: temporarily failed to flush the buffer. next_retry=2015-01-15 10:37:09 +0000 error_class="Aws::CloudWatchLogs::Errors::InvalidSequenceTokenException" error="The given sequenceToken is invalid. The next expected sequenceToken is: 49542672486808773264381019708032531348811120384399118754" plugin_id="object:3ff007cf4b1c"
```

The message includes expected sequenceToken, so I wrote retry code using it.

Thanks