### PR TITLE
Obey more of Amazon's restrictions on PutLogEvents

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Fetch sample log from CloudWatch Logs:
 * `auto_create_stream`: to create log group and stream automatically
 * `message_keys`: keys to send messages as events
 * `max_message_length`: maximum length of the message
+* `max_events_per_batch`: maximum number of events to send at once (default 10000)
 * `use_tag_as_group`: to use tag as a group name
 * `use_tag_as_stream`: to use tag as a stream name
 

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -10,6 +10,7 @@ module Fluent
     config_param :auto_create_stream, :bool, default: false
     config_param :message_keys, :string, :default => nil
     config_param :max_message_length, :integer, :default => nil
+    config_param :max_events_per_batch, :integer, :default => 10000
     config_param :use_tag_as_group, :bool, :default => false
     config_param :use_tag_as_stream, :bool, :default => false
     config_param :http_proxy, :string, default: nil
@@ -106,7 +107,9 @@ module Fluent
       # The maximum batch size is 1,048,576 bytes, and this size is calculated as the sum of all event messages in UTF-8, plus 26 bytes for each log event.
       # http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html
       while event = events.shift
-        if (chunk + [event]).inject(0) {|sum, e| sum + e[:message].length + 26 } > MAX_EVENTS_SIZE
+        chunk_too_big = (chunk + [event]).inject(0) {|sum, e| sum + e[:message].length + 26 } > MAX_EVENTS_SIZE
+        chunk_too_long = @max_events_per_batch && chunk.size >= @max_events_per_batch
+        if chunk_too_big or chunk_too_long
           put_events(group_name, stream_name, chunk)
           chunk = [event]
         else

--- a/test/plugin/test_out_cloudwatch_logs.rb
+++ b/test/plugin/test_out_cloudwatch_logs.rb
@@ -54,6 +54,28 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
     assert_equal('{"cloudwatch":"logs2"}', events[1].message)
   end
 
+  def test_write_24h_apart
+    new_log_stream
+
+    d = create_driver
+    time = Time.now
+    d.emit({'cloudwatch' => 'logs0'}, time.to_i - 60 * 60 * 25)
+    d.emit({'cloudwatch' => 'logs1'}, time.to_i)
+    d.emit({'cloudwatch' => 'logs2'}, time.to_i + 1)
+    d.run
+
+    sleep 20
+
+    events = get_log_events
+    assert_equal(3, events.size)
+    assert_equal((time.to_i - 60 * 60 * 25) * 1000, events[0].timestamp)
+    assert_equal('{"cloudwatch":"logs0"}', events[0].message)
+    assert_equal((time.to_i ) * 1000, events[1].timestamp)
+    assert_equal('{"cloudwatch":"logs1"}', events[1].message)
+    assert_equal((time.to_i + 1) * 1000, events[2].timestamp)
+    assert_equal('{"cloudwatch":"logs2"}', events[2].message)
+  end
+
   def test_write_with_message_keys
     new_log_stream
 


### PR DESCRIPTION
I discovered these two issues when testing a tail input with `read_from_head=true` on a log file with many old entries.