### PR TITLE
Add use_log_stream_name_prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Fetch sample log from CloudWatch Logs:
   tag cloudwatch.in
   log_group_name group
   log_stream_name stream
+  #use_log_stream_name_prefix true
   state_file /var/lib/fluent/group_stream.in.state
 </source>
 ```
@@ -101,6 +102,7 @@ Fetch sample log from CloudWatch Logs:
 * `tag`: fluentd tag
 * `log_group_name`: name of log group to fetch logs
 * `log_stream_name`: name of log stream to fetch logs
+* `use_log_stream_name_prefix`: to use `log_stream_name` as log stream name prefix (default false)
 * `state_file`: file to store current state (e.g. next\_forward\_token)
 
 ## Test

--- a/test/plugin/test_in_cloudwatch_logs.rb
+++ b/test/plugin/test_in_cloudwatch_logs.rb
@@ -22,6 +22,7 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
       tag test
       log_group_name group
       log_stream_name stream
+      use_log_stream_name_prefix true
       state_file /tmp/state
     EOC
 
@@ -31,6 +32,7 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
     assert_equal('test', d.instance.tag)
     assert_equal('group', d.instance.log_group_name)
     assert_equal('stream', d.instance.log_stream_name)
+    assert_equal(true, d.instance.use_log_stream_name_prefix)
     assert_equal('/tmp/state', d.instance.state_file)
   end
 
@@ -91,6 +93,48 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
     assert_equal('test', emits[1][0])
     assert_in_delta((time_ms / 1000).floor, emits[1][1], 10)
     assert_equal({'cloudwatch' => 'logs2'}, emits[1][2])
+  end
+
+  def test_emit_with_prefix
+    new_log_stream("testprefix")
+    create_log_stream
+
+    time_ms = (Time.now.to_f * 1000).floor
+    put_log_events([
+      {timestamp: time_ms, message: '{"cloudwatch":"logs1"}'},
+      {timestamp: time_ms, message: '{"cloudwatch":"logs2"}'},
+    ])
+
+    new_log_stream("testprefix")
+    create_log_stream
+    put_log_events([
+      {timestamp: time_ms, message: '{"cloudwatch":"logs3"}'},
+      {timestamp: time_ms, message: '{"cloudwatch":"logs4"}'},
+    ])
+
+    sleep 5
+
+    d = create_driver(<<-EOC)
+      tag test
+      type cloudwatch_logs
+      log_group_name #{log_group_name}
+      log_stream_name testprefix
+      use_log_stream_name_prefix true
+      state_file /tmp/state
+      #{aws_key_id}
+      #{aws_sec_key}
+      #{region}
+    EOC
+    d.run do
+      sleep 5
+    end
+
+    emits = d.emits
+    assert_equal(4, emits.size)
+    assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs1'}], emits[0])
+    assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs2'}], emits[1])
+    assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs3'}], emits[2])
+    assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs4'}], emits[3])
   end
 
   private

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,15 +29,15 @@ module CloudwatchLogsTestHelper
     "region #{ENV['region']}" if ENV['region']
   end
 
-  def log_stream_name
+  def log_stream_name(log_stream_name_prefix = nil)
     if !@log_stream_name
-      new_log_stream
+      new_log_stream(log_stream_name_prefix)
     end
     @log_stream_name
   end
 
-  def new_log_stream
-    @log_stream_name = Time.now.to_f.to_s
+  def new_log_stream(log_stream_name_prefix = nil)
+    @log_stream_name = log_stream_name_prefix ? log_stream_name_prefix + Time.now.to_f.to_s : Time.now.to_f.to_s
   end
 
   def clear_log_group
@@ -54,7 +54,7 @@ module CloudwatchLogsTestHelper
     @fluentd_tag ||= "fluent.plugin.cloudwatch.test.#{Time.now.to_f}"
   end
 
-  def create_log_stream
+  def create_log_stream()
     begin
       logs.create_log_group(log_group_name: log_group_name)
     rescue Aws::CloudWatchLogs::Errors::ResourceAlreadyExistsException


### PR DESCRIPTION
I added the option to specify a prefix of the log stream to obtain a plurality of log stream in the log group .