### PR TITLE
Use UTF-8 instead

### DIFF
--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -77,7 +77,9 @@ module Fluent
             message = record.to_json
           end
 
-          message.force_encoding('ASCII-8BIT')
+          # CloudWatchLogs API only accepts valid UTF-8 strings
+          # so we should encode the message to UTF-8
+          message.encode('UTF-8', :invalid => :replace)
 
           if @max_message_length
             message = message.slice(0, @max_message_length)
@@ -109,7 +111,7 @@ module Fluent
       while event = events.shift
         new_chunk = chunk + [event]
         chunk_span_too_big = new_chunk.size > 1 && new_chunk[-1][:timestamp] - new_chunk[0][:timestamp] >= 1000 * 60 * 60 * 24
-        chunk_too_big = new_chunk.inject(0) {|sum, e| sum + e[:message].length + 26 } > MAX_EVENTS_SIZE
+        chunk_too_big = new_chunk.inject(0) {|sum, e| sum + e[:message].bytesize + 26 } > MAX_EVENTS_SIZE
         chunk_too_long = @max_events_per_batch && chunk.size >= @max_events_per_batch
         if chunk_too_big or chunk_span_too_big or chunk_too_long
           put_events(group_name, stream_name, chunk)

--- a/test/plugin/test_out_cloudwatch_logs.rb
+++ b/test/plugin/test_out_cloudwatch_logs.rb
@@ -54,6 +54,22 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
     assert_equal('{"cloudwatch":"logs2"}', events[1].message)
   end
 
+  def test_write_utf8
+    new_log_stream
+
+    d = create_driver
+    time = Time.now
+    d.emit({'cloudwatch' => 'これは日本語です'.force_encoding('UTF-8')}, time.to_i)
+    d.run
+
+    sleep 20
+
+    events = get_log_events
+    assert_equal(1, events.size)
+    assert_equal(time.to_i * 1000, events[0].timestamp)
+    assert_equal('{"cloudwatch":"これは日本語です"}', events[0].message)
+  end
+
   def test_write_24h_apart
     new_log_stream
 


### PR DESCRIPTION
[CloudWatch Logs API can accept](http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html) UTF-8 but this plugin sets `force_encoding('ASCII-8BIT')` and it prevents us from sending messages that has valid UTF-8 string.

## Changes

- Use String#encode to encode strings to UTF-8 and set `:invalid => :replace` to ensure that invalid UTF-8 strings will be replaced and let the plugin continues working
- Use String#bytesize instead of String#length