### PR TITLE
Remove references to sequence_token_file parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ Fetch sample log from CloudWatch Logs:
 
 * `log_group_name`: name of log group to store logs
 * `log_stream_name`: name of log stream to store logs
-* `sequence_token_file`: file to store next sequence token
 * `auto_create_stream`: to create log group and stream automatically
 * `message_keys`: keys to send messages as events
 * `max_message_length`: maximum length of the message

--- a/example/fluentd.conf
+++ b/example/fluentd.conf
@@ -14,7 +14,6 @@
   type cloudwatch_logs
   log_group_name fluent-plugin-cloudwatch-example
   log_stream_name fluent-plugin-cloudwatch-example
-  sequence_token_file /tmp/fluent-plugin-cloudwatch-example.seq
   auto_create_stream true
 </match>
 

--- a/test/plugin/test_out_cloudwatch_logs.rb
+++ b/test/plugin/test_out_cloudwatch_logs.rb
@@ -12,7 +12,6 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
 
   def teardown
     clear_log_group
-    FileUtils.rm_f(sequence_token_file)
   end
 
 
@@ -177,18 +176,12 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
     type cloudwatch_logs
     log_group_name #{log_group_name}
     log_stream_name #{log_stream_name}
-    sequence_token_file #{sequence_token_file}
     auto_create_stream true
     #{aws_key_id}
     #{aws_sec_key}
     #{region}
     EOC
   end
-
-  def sequence_token_file
-    File.expand_path('../../tmp/sequence_token', __FILE__)
-  end
-
 
   def create_driver(conf = default_config)
     Fluent::Test::BufferedOutputTestDriver.new(Fluent::CloudwatchLogsOutput, fluentd_tag).configure(conf)


### PR DESCRIPTION
Remove references to the `sequence_token_file` configuration parameter, since it is no longer in use.