### PR TITLE
Minor spelling fixes in out_cloudwatch_logs

### DIFF
--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -54,7 +54,7 @@ module Fluent
           if @auto_create_stream
             create_log_group(group_name)
           else
-            log.warn "Log group '#{group_name}' dose not exists"
+            log.warn "Log group '#{group_name}' does not exist"
             next
           end
         end
@@ -63,7 +63,7 @@ module Fluent
           if @auto_create_stream
             create_log_stream(group_name, stream_name)
           else
-            log.warn "Log stream '#{stream_name}' dose not exists"
+            log.warn "Log stream '#{stream_name}' does not exist"
             next
           end
         end


### PR DESCRIPTION
Minor spelling fixes in `out_cloudwatch_logs` when log group/stream already exists.