### PR TITLE
Implement include_time_key for log entry records

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Fetch sample log from CloudWatch Logs:
   #max_message_length 32768
   #use_tag_as_group false
   #use_tag_as_stream false
+  #include_time_key true
+  #localtime true
 </match>
 ```
 
@@ -85,6 +87,8 @@ Fetch sample log from CloudWatch Logs:
 * `max_events_per_batch`: maximum number of events to send at once (default 10000)
 * `use_tag_as_group`: to use tag as a group name
 * `use_tag_as_stream`: to use tag as a stream name
+* `include_time_key`: include time key as part of the log entry (defaults to UTC)
+* `localtime`: use localtime timezone for `include_time_key` output (overrides UTC default)
 
 ### in_cloudwatch_logs
 

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -2,6 +2,8 @@ module Fluent
   class CloudwatchLogsOutput < BufferedOutput
     Plugin.register_output('cloudwatch_logs', self)
 
+    include Fluent::SetTimeKeyMixin
+
     config_param :aws_key_id, :string, :default => nil, :secret => true
     config_param :aws_sec_key, :string, :default => nil, :secret => true
     config_param :region, :string, :default => nil


### PR DESCRIPTION
Closes #25 

Add `include_time_key` configuration option for adding time field to CW log entries.