### PR TITLE
Ensure group name key exists before adding stream name

### DIFF
--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -153,6 +153,7 @@ module Fluent
     def create_log_stream(group_name, stream_name)
       begin
         @logs.create_log_stream(log_group_name: group_name, log_stream_name: stream_name)
+        @sequence_tokens[group_name] ||= {}
         @sequence_tokens[group_name][stream_name] = nil
       rescue Aws::CloudWatchLogs::Errors::ResourceAlreadyExistsException
         log.debug "Log stream '#{stream_name}' already exists"


### PR DESCRIPTION
When `use_tag_as_group` is used, I will get an exception because the group name key doesn't actually exist.  I was unable to reliably reproduce this, but it seems to happen depending on the results of querying the AWS API.  This simple change just ensures that the hash actually exists before adding the stream.