### PR TITLE
use_log_stream_name_prefix=trueで、複数のログストリームから取得できない問題を解消

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -111,7 +111,7 @@ module Fluent
       }
       request[:next_token] = next_token if next_token
       response = @logs.get_log_events(request)
-      store_next_token(response.next_forward_token)
+      store_next_token(response.next_forward_token, log_stream_name)
 
       response.events
     end


### PR DESCRIPTION
AWSで、ロググループ「hogehoge_group」の、"i-"から始まる複数のログストリームをすべて収集しようとしています。
設定はこのように。
```
<source>
  @type cloudwatch_logs
  tag hogehoge.log.in
  log_group_name hogehoge_group
  log_stream_name i-
  use_log_stream_name_prefix true
  state_file /tmp/hogehoge.log.in.state
  format /^(?<time>[A-Za-z]{3} \d{1,2} \d{1,2}:\d{1,2}:\d{1,2}) (?<host>[^ ]*) (?<message>.*)?/
</source>
```
このとき、get_eventsはログストリームの本数分よびだされるのに、store_next_tokenにログストリーム名を渡していないために、トークンが使いまわされます。
https://github.com/ryotarai/fluent-plugin-cloudwatch-logs/blob/master/lib/fluent/plugin/in_cloudwatch_logs.rb#L80

そのため、state fileが存在しない初回起動時の、eachして取れた最初のログストリームからはログデータを取れますが、それ以外のログストリームは、トークンとログストリームが一致しないため、取得できません。
https://github.com/ryotarai/fluent-plugin-cloudwatch-logs/blob/master/lib/fluent/plugin/in_cloudwatch_logs.rb#L78

store_next_tokenにログストリーム名を渡し、トークンを使い回すことがないよう改めます。