### PR TITLE
Retry after invalid sequence token exception

### DIFF
--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -211,6 +211,10 @@ module Fluent
         }
         begin
           response = @logs.put_log_events(args)
+        rescue Aws::CloudWatchLogs::Errors::InvalidSequenceTokenException
+          log_stream = find_log_stream(group_name, stream_name)
+          store_next_sequence_token(group_name, stream_name, log_stream.upload_sequence_token)
+          retry
         rescue Aws::CloudWatchLogs::Errors::ThrottlingException => err
           if !@put_log_events_disable_retry_limit && @put_log_events_retry_limit < retry_count
             log.error "failed to PutLogEvents and discard logs because retry count exceeded put_log_events_retry_limit", {


### PR DESCRIPTION
If you are logging to the same stream from multiple sources an Aws::CloudWatchLogs::Errors::InvalidSequenceTokenException can be thrown. In this case the old sequence token will be tried over and over again causing the same error.

With these changes the plugin recovers from this state by updating the sequence token for the stream. I also need to wait for a bit because otherwise I run into a throttling exception. This fixes #32 