### PR TITLE
Retry PutLogEvents after ThrottlingException error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Fetch sample log from CloudWatch Logs:
   #log_stream_name_key stream_name_key
   #remove_log_group_name_key true
   #remove_log_stream_name_key true
+  #put_log_events_retry_wait 1s
+  #put_log_events_retry_limit 17
+  #put_log_events_disable_retry_limit false
 </match>
 ```
 
@@ -96,6 +99,9 @@ Fetch sample log from CloudWatch Logs:
 * `log_stream_name_key`: use specified field of records as log stream name
 * `remove_log_group_name_key`: remove field specified by `log_group_name_key`
 * `remove_log_stream_name_key`: remove field specified by `log_stream_name_key`
+* `put_log_events_retry_wait`: time before retrying PutLogEvents (retry interval increases exponentially like `put_log_events_retry_wait * (2 ^ retry_count)`)
+* `put_log_events_retry_limit`: maximum count of retry (if exceeding this, the events will be discarded)
+* `put_log_events_disable_retry_limit`: if true, `put_log_events_retry_limit` will be ignored
 
 ### in_cloudwatch_logs
 

--- a/fluent-plugin-cloudwatch-logs.gemspec
+++ b/fluent-plugin-cloudwatch-logs.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit"
+  spec.add_development_dependency "mocha"
 end

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -214,6 +214,7 @@ module Fluent
             return
           else
             sleep_sec = @put_log_events_retry_wait * (2 ** retry_count)
+            sleep_sec += sleep_sec * (0.25 * (rand - 0.5))
             log.warn "failed to PutLogEvents", {
               "next_retry" => Time.now + sleep_sec,
               "error_class" => err.class.to_s,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 require 'test/unit'
+require 'mocha/test_unit'
 require 'fluent/test'
 
 require 'aws-sdk-core'


### PR DESCRIPTION
This issue is reported by @eagletmt

If an exception like ThrottlingException is raised, fluentd preserves the chunk and retry to write later. But some part of the chunk data may be sent successfully before the exception. It can cause duplicated logs on CloudWatch Logs.

This PR introduces retrying after ThrottlingException error.