### PR TITLE
Reduce PutLogEvents API calls

### DIFF
--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -73,7 +73,7 @@ module Fluent
     end
 
     def write(chunk)
-      chunk.enum_for(:msgpack_each).chunk {|tag, time, record|
+      chunk.enum_for(:msgpack_each).group_by {|tag, time, record|
         group = case
                 when @use_tag_as_group
                   tag

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -73,7 +73,6 @@ module Fluent
     end
 
     def write(chunk)
-      events = []
       chunk.enum_for(:msgpack_each).chunk {|tag, time, record|
         group = case
                 when @use_tag_as_group
@@ -123,6 +122,7 @@ module Fluent
           end
         end
 
+        events = []
         rs.each do |t, time, record|
           time_ms = time * 1000
 

--- a/test/plugin/test_out_cloudwatch_logs.rb
+++ b/test/plugin/test_out_cloudwatch_logs.rb
@@ -254,18 +254,36 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
     log_stream_name_key stream_name_key
     EOC
 
-    record = {'cloudwatch' => 'logs1', 'message' => 'message1', 'group_name_key' => log_group_name, 'stream_name_key' => log_stream_name}
+    stream1 = new_log_stream
+    stream2 = new_log_stream
+
+    records = [
+      {'cloudwatch' => 'logs1', 'message' => 'message1', 'group_name_key' => log_group_name, 'stream_name_key' => stream1},
+      {'cloudwatch' => 'logs2', 'message' => 'message1', 'group_name_key' => log_group_name, 'stream_name_key' => stream2},
+      {'cloudwatch' => 'logs3', 'message' => 'message1', 'group_name_key' => log_group_name, 'stream_name_key' => stream1},
+    ]
 
     time = Time.now
-    d.emit(record, time.to_i)
+    records.each_with_index do |record, i|
+      d.emit(record, time.to_i + i)
+    end
     d.run
 
-    sleep 10
+    puts d.instance.log.logs
 
-    events = get_log_events(log_group_name, log_stream_name)
-    assert_equal(1, events.size)
+    sleep 60
+
+    events = get_log_events(log_group_name, stream1)
+    assert_equal(2, events.size)
     assert_equal(time.to_i * 1000, events[0].timestamp)
-    assert_equal(record, JSON.parse(events[0].message))
+    assert_equal((time.to_i + 2) * 1000, events[1].timestamp)
+    assert_equal(records[0], JSON.parse(events[0].message))
+    assert_equal(records[2], JSON.parse(events[1].message))
+
+    events = get_log_events(log_group_name, stream2)
+    assert_equal(1, events.size)
+    assert_equal((time.to_i + 1) * 1000, events[0].timestamp)
+    assert_equal(records[1], JSON.parse(events[0].message))
   end
 
   def test_remove_log_group_name_key_and_remove_log_stream_name_key

--- a/test/plugin/test_out_cloudwatch_logs.rb
+++ b/test/plugin/test_out_cloudwatch_logs.rb
@@ -269,9 +269,10 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
     end
     d.run
 
-    puts d.instance.log.logs
+    # Call API once for each stream
+    assert_equal(2, d.instance.log.logs.select {|l| l =~ /Calling PutLogEvents API/ }.size)
 
-    sleep 60
+    sleep 10
 
     events = get_log_events(log_group_name, stream1)
     assert_equal(2, events.size)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 require 'test/unit'
 require 'mocha/test_unit'
 require 'fluent/test'
+require 'securerandom'
 
 require 'aws-sdk-core'
 
@@ -38,7 +39,8 @@ module CloudwatchLogsTestHelper
   end
 
   def new_log_stream(log_stream_name_prefix = nil)
-    @log_stream_name = log_stream_name_prefix ? log_stream_name_prefix + Time.now.to_f.to_s : Time.now.to_f.to_s
+    uuid = SecureRandom.uuid
+    @log_stream_name = log_stream_name_prefix ? log_stream_name_prefix + uuid : uuid
   end
 
   def clear_log_group


### PR DESCRIPTION
If events are to the same log stream, send events in a batch.