### PR TITLE
replace path separators in log stream name with dashes

### DIFF
--- a/lib/fluent/plugin/cloudwatch/logs/version.rb
+++ b/lib/fluent/plugin/cloudwatch/logs/version.rb
@@ -2,7 +2,7 @@ module Fluent
   module Plugin
     module Cloudwatch
       module Logs
-        VERSION = "0.3.3"
+        VERSION = "0.3.4"
       end
     end
   end

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -107,11 +107,10 @@ module Fluent
     def emit(stream, event)
       if @parser
         record = @parser.parse(event.message)
-        router.emit("#{@tag}.#{stream}", record[0], record[1])
+        router.emit("#{@tag}.#{stream}", event.timestamp, record[1])
       else
-        time = (event.timestamp / 1000).floor
         record = JSON.parse(event.message)
-        router.emit("#{@tag}.#{stream}", time, record)
+        router.emit("#{@tag}.#{stream}", event.timestamp, record)
       end
     end
 

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -61,15 +61,18 @@ module Fluent
       end
     end
 
-    def next_token
-      return nil unless File.exist?(@state_file)
-      File.read(@state_file).chomp
+    def state_file_for(log_stream_name = nil)
+      return "#{@state_file}_#{log_stream_name.gsub(File::SEPARATOR, '-')}" if log_stream_name
+      return @state_file
+    end
+
+    def next_token(log_stream_name)
+      return nil unless File.exist?(state_file_for(log_stream_name))
+      File.read(state_file_for(log_stream_name)).chomp
     end
 
     def store_next_token(token, log_stream_name = nil)
-      state_file = @state_file
-      state_file = "#{@state_file}_#{log_stream_name.gsub(File::SEPARATOR, '-')}" if log_stream_name
-      open(state_file, 'w') do |f|
+      open(state_file_for(log_stream_name), 'w') do |f|
         f.write token
       end
     end
@@ -117,7 +120,7 @@ module Fluent
         log_group_name: @log_group_name,
         log_stream_name: log_stream_name
       }
-      request[:next_token] = next_token if next_token
+      request[:next_token] = next_token(log_stream_name) if next_token(log_stream_name)
       response = @logs.get_log_events(request)
       store_next_token(response.next_forward_token, log_stream_name)
 

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -90,13 +90,13 @@ module Fluent
               log_stream_name = log_stram.log_stream_name
               events = get_events(log_stream_name)
               events.each do |event|
-                emit(event)
+                emit(log_stream_name, event)
               end
             end
           else
             events = get_events(@log_stream_name)
             events.each do |event|
-              emit(event)
+              emit(@log_stream_name, event)
             end
           end
         end
@@ -104,14 +104,14 @@ module Fluent
       end
     end
 
-    def emit(event)
+    def emit(stream, event)
       if @parser
         record = @parser.parse(event.message)
-        router.emit(@tag, record[0], record[1])
+        router.emit("#{@tag}.#{stream}", record[0], record[1])
       else
         time = (event.timestamp / 1000).floor
         record = JSON.parse(event.message)
-        router.emit(@tag, time, record)
+        router.emit("#{@tag}.#{stream}", time, record)
       end
     end
 

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -68,7 +68,7 @@ module Fluent
 
     def store_next_token(token, log_stream_name = nil)
       state_file = @state_file
-      state_file = "#{@state_file}_#{log_stream_name}" if log_stream_name
+      state_file = "#{@state_file}_#{log_stream_name.gsub(File::SEPARATOR, '-')}" if log_stream_name
       open(state_file, 'w') do |f|
         f.write token
       end

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -107,10 +107,10 @@ module Fluent
     def emit(stream, event)
       if @parser
         record = @parser.parse(event.message)
-        router.emit("#{@tag}.#{stream}", event.timestamp, record[1])
+        router.emit("#{@tag}.#{stream}", event.timestamp / 1000, record[1])
       else
         record = JSON.parse(event.message)
-        router.emit("#{@tag}.#{stream}", event.timestamp, record)
+        router.emit("#{@tag}.#{stream}", event.timestamp / 1000, record)
       end
     end
 


### PR DESCRIPTION
I have log streams in AWS Cloudwatch that contain slashes.
