### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in fluent-plugin-cloudwatch-logs.gemspec
-gem 'fluentd', '~> 0.12.0'
 gemspec

--- a/fluent-plugin-cloudwatch-logs.gemspec
+++ b/fluent-plugin-cloudwatch-logs.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fluentd'
+  spec.add_dependency 'fluentd', '>= 0.14.15'
   spec.add_dependency 'aws-sdk-core', '~> 2.0'
   spec.add_dependency 'fluent-mixin-config-placeholders', '>= 0.2.0'
 

--- a/fluent-plugin-cloudwatch-logs.gemspec
+++ b/fluent-plugin-cloudwatch-logs.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'fluentd', '>= 0.14.15'
   spec.add_dependency 'aws-sdk-core', '~> 2.0'
-  spec.add_dependency 'fluent-mixin-config-placeholders', '>= 0.2.0'
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/test/plugin/test_in_cloudwatch_logs.rb
+++ b/test/plugin/test_in_cloudwatch_logs.rb
@@ -1,7 +1,10 @@
 require 'test_helper'
+require 'fluent/test/driver/input'
+require 'fluent/test/helpers'
 
 class CloudwatchLogsInputTest < Test::Unit::TestCase
   include CloudwatchLogsTestHelper
+  include Fluent::Test::Helpers
 
   def setup
     Fluent::Test.setup
@@ -48,11 +51,9 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
     sleep 5
 
     d = create_driver
-    d.run do
-      sleep 5
-    end
+    d.run(expect_emits: 2, timeout: 5)
 
-    emits = d.emits
+    emits = d.events
     assert_equal(2, emits.size)
     assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs1'}], emits[0])
     assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs2'}], emits[1])
@@ -81,11 +82,9 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
       #{region}
     EOC
 
-    d.run do
-      sleep 5
-    end
+    d.run(expect_emits: 2, timeout: 5)
 
-    emits = d.emits
+    emits = d.events
     assert_equal(2, emits.size)
     assert_equal('test', emits[0][0])
     assert_in_delta((time_ms / 1000).floor, emits[0][1], 10)
@@ -125,11 +124,9 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
       #{aws_sec_key}
       #{region}
     EOC
-    d.run do
-      sleep 5
-    end
+    d.run(expect_emits: 4, timeout: 5)
 
-    emits = d.emits
+    emits = d.events
     assert_equal(4, emits.size)
     assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs1'}], emits[0])
     assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs2'}], emits[1])
@@ -145,6 +142,7 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
       log_group_name #{log_group_name}
       log_stream_name #{log_stream_name}
       state_file /tmp/state
+      fetch_interval 1
       #{aws_key_id}
       #{aws_sec_key}
       #{region}
@@ -152,6 +150,6 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
   end
 
   def create_driver(conf = default_config)
-    Fluent::Test::InputTestDriver.new(Fluent::CloudwatchLogsInput).configure(conf)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::CloudwatchLogsInput).configure(conf)
   end
 end


### PR DESCRIPTION
I've tried to migrate to use v0.14 Input/Output Plugin API.
This PR contains major update change.
Could you bump up minor version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks,

Will fix https://github.com/ryotarai/fluent-plugin-cloudwatch-logs/issues/54.