### PR TITLE
Add auto_create_group parameter

### DIFF
--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -15,6 +15,7 @@ module Fluent
     config_param :log_group_name, :string, :default => nil
     config_param :log_stream_name, :string, :default => nil
     config_param :auto_create_stream, :bool, default: false
+    config_param :auto_create_group, :bool, default: false
     config_param :message_keys, :string, :default => nil
     config_param :max_message_length, :integer, :default => nil
     config_param :max_events_per_batch, :integer, :default => 10000
@@ -119,7 +120,7 @@ module Fluent
         end
 
         unless log_group_exists?(group_name)
-          if @auto_create_stream
+          if @auto_create_group
             create_log_group(group_name)
           else
             log.warn "Log group '#{group_name}' does not exist"


### PR DESCRIPTION
We create CloudWatchLog groups using CloudFormation. If we enable Fluentd to auto-create the log streams it will also auto-create the log groups which conflicts with CloudFormation. To avoid this we introduced the new auto_create_groups parameter to be able to configure this separately