### PR TITLE
AWS sdk to stick to v2 

### DIFF
--- a/fluent-plugin-cloudwatch-logs.gemspec
+++ b/fluent-plugin-cloudwatch-logs.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'fluentd'
-  spec.add_dependency 'aws-sdk-core', '~> 2.10.9'
+  spec.add_dependency 'aws-sdk-core', '~> 2.0'
   spec.add_dependency 'fluent-mixin-config-placeholders', '>= 0.2.0'
 
   spec.add_development_dependency "bundler", "~> 1.6"

--- a/fluent-plugin-cloudwatch-logs.gemspec
+++ b/fluent-plugin-cloudwatch-logs.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'fluentd'
-  spec.add_dependency 'aws-sdk-core', '>= 2.0.7'
+  spec.add_dependency 'aws-sdk-core', '~>2.0'
   spec.add_dependency 'fluent-mixin-config-placeholders', '>= 0.2.0'
 
   spec.add_development_dependency "bundler", "~> 1.6"

--- a/fluent-plugin-cloudwatch-logs.gemspec
+++ b/fluent-plugin-cloudwatch-logs.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'fluentd'
-  spec.add_dependency 'aws-sdk-core', '~> 2.0'
+  spec.add_dependency 'aws-sdk-core', '~> 2.10.9'
   spec.add_dependency 'fluent-mixin-config-placeholders', '>= 0.2.0'
 
   spec.add_development_dependency "bundler", "~> 1.6"

--- a/fluent-plugin-cloudwatch-logs.gemspec
+++ b/fluent-plugin-cloudwatch-logs.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'fluentd'
-  spec.add_dependency 'aws-sdk-core', '~>2.0'
+  spec.add_dependency 'aws-sdk-core', '~> 2.0'
   spec.add_dependency 'fluent-mixin-config-placeholders', '>= 0.2.0'
 
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
Currently the plugin will install aws-sdk-core v3 as it has > 2.0 which will cause an error.
Check details here https://github.com/ryotarai/fluent-plugin-cloudwatch-logs/issues/77