### PR TITLE
replace path separators in log stream name with dashes

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -123,10 +123,11 @@ module Fluent
     def emit(stream, event)
       if @parser
         record = @parser.parse(event.message)
-        router.emit("#{@tag}", event.timestamp / 1000, record[1])
+        router.emit(@tag, record[0], record[1])
       else
+        time = (event.timestamp / 1000).floor
         record = JSON.parse(event.message)
-        router.emit("#{@tag}", event.timestamp / 1000, record)
+        router.emit(@tag, time, record)
       end
     end
 

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -77,15 +77,18 @@ module Fluent
       end
     end
 
-    def next_token
-      return nil unless File.exist?(@state_file)
-      File.read(@state_file).chomp
+    def state_file_for(log_stream_name = nil)
+      return "#{@state_file}_#{log_stream_name.gsub(File::SEPARATOR, '-')}" if log_stream_name
+      return @state_file
+    end
+
+    def next_token(log_stream_name)
+      return nil unless File.exist?(state_file_for(log_stream_name))
+      File.read(state_file_for(log_stream_name)).chomp
     end
 
     def store_next_token(token, log_stream_name = nil)
-      state_file = @state_file
-      state_file = "#{@state_file}_#{log_stream_name}" if log_stream_name
-      open(state_file, 'w') do |f|
+      open(state_file_for(log_stream_name), 'w') do |f|
         f.write token
       end
     end
@@ -103,13 +106,13 @@ module Fluent
               log_stream_name = log_stram.log_stream_name
               events = get_events(log_stream_name)
               events.each do |event|
-                emit(event)
+                emit(log_stream_name, event)
               end
             end
           else
             events = get_events(@log_stream_name)
             events.each do |event|
-              emit(event)
+              emit(log_stream_name, event)
             end
           end
         end
@@ -117,14 +120,13 @@ module Fluent
       end
     end
 
-    def emit(event)
+    def emit(stream, event)
       if @parser
         record = @parser.parse(event.message)
-        router.emit(@tag, record[0], record[1])
+        router.emit("#{@tag}", event.timestamp / 1000, record[1])
       else
-        time = (event.timestamp / 1000).floor
         record = JSON.parse(event.message)
-        router.emit(@tag, time, record)
+        router.emit("#{@tag}", event.timestamp / 1000, record)
       end
     end
 
@@ -133,7 +135,7 @@ module Fluent
         log_group_name: @log_group_name,
         log_stream_name: log_stream_name
       }
-      request[:next_token] = next_token if next_token
+      request[:next_token] = next_token(log_stream_name) if next_token(log_stream_name)
       response = @logs.get_log_events(request)
       store_next_token(response.next_forward_token, log_stream_name)
 

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -77,7 +77,7 @@ module Fluent
       end
     end
 
-    def state_file_for(log_stream_name = nil)
+    def state_file_for(log_stream_name)
       return "#{@state_file}_#{log_stream_name.gsub(File::SEPARATOR, '-')}" if log_stream_name
       return @state_file
     end


### PR DESCRIPTION
Same as https://github.com/ryotarai/fluent-plugin-cloudwatch-logs/pull/55
Sorry for toebbel, I did not know there was a reaction from him.
Fixed issues pointed out in code review.

Summary: Lambda generate LogStream with `/`. So that replace path separators in log stream name with dashes
cf. `YYYY/MM/DD/[$LATEST]<uuid>`

1 test was failed in my env.
Maybe my test preparation method is wrong.

```
Failure:
  </failed to PutLogEvents and throwing away/> was expected to be =~
  <"2017-09-28 11:21:36 +0900 [error]: failed to PutLogEvents and discard logs because retry count exceeded put_log_events_retry_limit error_class=\"Aws::CloudWatchLogs::Errors::ThrottlingException\" error=\"error\"\n">.
test_retrying_on_throttling_exception_and_throw_away(CloudwatchLogsOutputTest)
```

Another test occasionally fails. It may be a timing problem.
Perhaps the acquisition process of next_token may be wrong.

```
Failure: test_emit_with_prefix(CloudwatchLogsInputTest)
/path/fluent-plugin-cloudwatch-logs/test/plugin/test_in_cloudwatch_logs.rb:134:in `test_emit_with_prefix'
     131: 
     132:     emits = d.emits
     133:     assert_equal(4, emits.size)
  => 134:     assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs1'}], emits[0])
     135:     assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs2'}], emits[1])
     136:     assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs3'}], emits[2])
     137:     assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs4'}], emits[3])
<["test", 1506561706, {"cloudwatch"=>"logs1"}]> expected but was
<["test", 1506561706, {"cloudwatch"=>"logs3"}]>
```
```
[6] pry(#<CloudwatchLogsInputTest>)> d
=> #<Fluent::Test::InputTestDriver:0x007fc9593d3f40
 @config=
  {"tag"=>"test",
   "type"=>"cloudwatch_logs",
   "log_group_name"=>"fluent-plugin-cloudwatch-test-1506562482.71004",
   "log_stream_name"=>"testprefix",
   "use_log_stream_name_prefix"=>"true",
   "state_file"=>"/tmp/state"},
 @emit_streams=
  [["test", [[1506562485, {"cloudwatch"=>"logs3"}]]],
   ["test", [[1506562485, {"cloudwatch"=>"logs4"}]]],
   ["test", [[1506562485, {"cloudwatch"=>"logs1"}]]],
   ["test", [[1506562485, {"cloudwatch"=>"logs2"}]]]],
```