### PR TITLE
Prevent nesting of log_streams array

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -102,8 +102,8 @@ module Fluent
 
           if @use_log_stream_name_prefix
             log_streams = describe_log_streams
-            log_streams.each do |log_stram|
-              log_stream_name = log_stram.log_stream_name
+            log_streams.each do |log_stream|
+              log_stream_name = log_stream.log_stream_name
               events = get_events(log_stream_name)
               events.each do |event|
                 emit(log_stream_name, event)

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -151,7 +151,7 @@ module Fluent
       request[:log_stream_name_prefix] = @log_stream_name
       response = @logs.describe_log_streams(request)
       if log_streams
-        log_streams << response.log_streams
+        log_streams.concat(response.log_streams)
       else
         log_streams = response.log_streams
       end


### PR DESCRIPTION
I discovered that arrays become nested when dealing with 50 or more LogStreams.
In the CloudWatchLogs API, describe_log_streams returns 50 LogStreams.
Following the 51st and subsequent processes, since response.log_streams is an array, if you join by push, nesting of the array will occur.
For that reason, I changed it to concat.

```
    156:   response = @logs.describe_log_streams(request)
    157:   if log_streams
 => 158:     require "pry"; binding.pry
    159:     log_streams << response.log_streams
    160:     #log_streams.concat(response.log_streams)
    161:   else
    162:     log_streams = response.log_streams
    163:   end

[3] pry(#<Fluent::CloudwatchLogsInput>)> log_streams.each do |logstream|
[3] pry(#<Fluent::CloudwatchLogsInput>)*   p logstream.class  
[3] pry(#<Fluent::CloudwatchLogsInput>)* end  
Aws::CloudWatchLogs::Types::LogStream
Aws::CloudWatchLogs::Types::LogStream
...snip...
Array
```