### PR TITLE
aws sdk v3

### DIFF
--- a/fluent-plugin-cloudwatch-logs.gemspec
+++ b/fluent-plugin-cloudwatch-logs.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'fluentd'
-  spec.add_dependency 'aws-sdk-core', '~> 2.0'
+  spec.add_dependency 'aws-sdk-cloudwatchlogs', '~> 1.0'
   spec.add_dependency 'fluent-mixin-config-placeholders', '>= 0.2.0'
 
   spec.add_development_dependency "bundler", "~> 1.6"

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -31,7 +31,7 @@ module Fluent
     def initialize
       super
 
-      require 'aws-sdk-core'
+      require 'aws-sdk-cloudwatchlogs'
     end
 
     def placeholders

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -42,7 +42,7 @@ module Fluent
     def initialize
       super
 
-      require 'aws-sdk-core'
+      require 'aws-sdk-cloudwatchlogs'
     end
 
     def placeholders

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@ require 'mocha/test_unit'
 require 'fluent/test'
 require 'securerandom'
 
-require 'aws-sdk-core'
+require 'aws-sdk-cloudwatchlogs'
 
 module CloudwatchLogsTestHelper
   private


### PR DESCRIPTION
Updates aws sdk to v3 to work with other fluent plugins that have moved to aws sdk v3.
Resolves #77 