### PR TITLE
fix warn

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Fetch sample log from CloudWatch Logs:
 
 ```
 <match tag>
-  type cloudwatch_logs
+  @type cloudwatch_logs
   log_group_name log-group-name
   log_stream_name log-stream-name
   auto_create_stream true
@@ -107,7 +107,7 @@ Fetch sample log from CloudWatch Logs:
 
 ```
 <source>
-  type cloudwatch_logs
+  @type cloudwatch_logs
   tag cloudwatch.in
   log_group_name group
   log_stream_name stream
@@ -235,7 +235,7 @@ In this case IAM can be used to allow the fluentd instance in one account ("A") 
 ### Configuring the plugin for STS authentication
 ```
 <source>
-  type cloudwatch_logs
+  @type cloudwatch_logs
   region us-east-1      # You must supply a region
   aws_use_sts true
   aws_sts_role_arn arn:aws:iam::ACCOUNT-B:role/fluentd

--- a/example/fluentd.conf
+++ b/example/fluentd.conf
@@ -1,9 +1,9 @@
 <source>
-  type forward
+  @type forward
 </source>
 
 <source>
-  type cloudwatch_logs
+  @type cloudwatch_logs
   tag test.cloudwatch_logs.in
   log_group_name fluent-plugin-cloudwatch-example
   log_stream_name fluent-plugin-cloudwatch-example
@@ -11,13 +11,13 @@
 </source>
 
 <match test.cloudwatch_logs.out>
-  type cloudwatch_logs
+  @type cloudwatch_logs
   log_group_name fluent-plugin-cloudwatch-example
   log_stream_name fluent-plugin-cloudwatch-example
   auto_create_stream true
 </match>
 
 <match test.cloudwatch_logs.in>
-  type stdout
+  @type stdout
 </match>
 

--- a/test/plugin/test_in_cloudwatch_logs.rb
+++ b/test/plugin/test_in_cloudwatch_logs.rb
@@ -15,7 +15,7 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
 
   def test_configure
     d = create_driver(<<-EOC)
-      type cloudwatch_logs
+      @type cloudwatch_logs
       aws_key_id test_id
       aws_sec_key test_key
       region us-east-1
@@ -71,7 +71,7 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
 
     d = create_driver(<<-EOC)
       tag test
-      type cloudwatch_logs
+      @type cloudwatch_logs
       log_group_name #{log_group_name}
       log_stream_name #{log_stream_name}
       state_file /tmp/state
@@ -116,7 +116,7 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
 
     d = create_driver(<<-EOC)
       tag test
-      type cloudwatch_logs
+      @type cloudwatch_logs
       log_group_name #{log_group_name}
       log_stream_name testprefix
       use_log_stream_name_prefix true
@@ -141,7 +141,7 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
   def default_config
     <<-EOC
       tag test
-      type cloudwatch_logs
+      @type cloudwatch_logs
       log_group_name #{log_group_name}
       log_stream_name #{log_stream_name}
       state_file /tmp/state

--- a/test/plugin/test_out_cloudwatch_logs.rb
+++ b/test/plugin/test_out_cloudwatch_logs.rb
@@ -17,7 +17,7 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
 
   def test_configure
     d = create_driver(<<-EOC)
-      type cloudwatch_logs
+      @type cloudwatch_logs
       aws_key_id test_id
       aws_sec_key test_key
       region us-east-1
@@ -388,7 +388,7 @@ log_stream_name #{log_stream_name}
   private
   def default_config
     <<-EOC
-type cloudwatch_logs
+@type cloudwatch_logs
 auto_create_stream true
 #{aws_key_id}
 #{aws_sec_key}


### PR DESCRIPTION
Hello :)
It seems **type** parameter shows warn without @

```
2017-12-05 00:27:35 +0000 [warn]: 'type' is deprecated parameter name. use '@type' instead.
```