### PR TITLE
Add support for awstags and retention policy

### DIFF
--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -162,10 +162,7 @@ module Fluent
           end
 
           if @auto_create_stream
-            create_log_group(group_name, awstags)
-            unless retention_in_days.nil?
-              put_retention_policy(group_name, retention_in_days)
-            end
+            create_log_group(group_name, awstags, retention_in_days)
           else
             log.warn "Log group '#{group_name}' does not exist"
             next
@@ -354,9 +351,12 @@ module Fluent
       store_next_sequence_token(group_name, stream_name, response.next_sequence_token)
     end
 
-    def create_log_group(group_name, log_group_aws_tags = nil)
+    def create_log_group(group_name, log_group_aws_tags = nil, retention_in_days = nil)
       begin
         @logs.create_log_group(log_group_name: group_name, tags: log_group_aws_tags)
+        unless retention_in_days.nil?
+          put_retention_policy(group_name, retention_in_days)
+        end
         @sequence_tokens[group_name] = {}
       rescue Aws::CloudWatchLogs::Errors::ResourceAlreadyExistsException
         log.debug "Log group '#{group_name}' already exists"

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -155,9 +155,9 @@ module Fluent
           retention_in_days = @retention_in_days
           unless @retention_in_days_key.nil?
             if @remove_retention_in_days_key
-              awstags = record.delete(@retention_in_days_key)
+              retention_in_days = record.delete(@retention_in_days_key)
             else
-              awstags = record[@retention_in_days_key]
+              retention_in_days = record[@retention_in_days_key]
             end
           end
 

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -30,6 +30,12 @@ module Fluent
     config_param :put_log_events_retry_limit, :integer, default: 17
     config_param :put_log_events_disable_retry_limit, :bool, default: false
     config_param :concurrency, :integer, default: 1
+    config_param :log_group_aws_tags, :hash, default: nil
+    config_param :log_group_aws_tags_key, :string, default: nil
+    config_param :remove_log_group_aws_tags_key, :bool, default: false
+    config_param :retention_in_days, :integer, default: nil
+    config_param :retention_in_days_key, :string, default: nil
+    config_param :remove_retention_in_days, :bool, default: false
 
     MAX_EVENTS_SIZE = 1_048_576
     MAX_EVENT_SIZE = 256 * 1024
@@ -58,6 +64,14 @@ module Fluent
 
       unless [conf['log_stream_name'], conf['use_tag_as_stream'], conf['log_stream_name_key']].compact.size == 1
         raise ConfigError, "Set only one of log_stream_name, use_tag_as_stream and log_stream_name_key"
+      end
+
+      if [conf['log_group_aws_tags'], conf['log_group_aws_tags_key']].compact.size > 1
+        raise ConfigError, "Set only one of log_group_aws_tags, log_group_aws_tags_key"
+      end
+
+      if [conf['retention_in_days'], conf['retention_in_days_key']].compact.size > 1
+        raise ConfigError, "Set only one of retention_in_days, retention_in_days_key"
       end
     end
 
@@ -124,8 +138,34 @@ module Fluent
         end
 
         unless log_group_exists?(group_name)
+          #rs = [[name, timestamp, record],[name,timestamp,record]]
+          #get tags and retention from first record
+          #as we create log group only once, values from first record will persist
+          record = rs[0][2]
+
+          awstags = @log_group_aws_tags
+          unless @log_group_aws_tags_key.nil?
+            if @remove_log_group_aws_tags_key
+              awstags = record.delete(@log_group_aws_tags_key)
+            else
+              awstags = record[@log_group_aws_tags_key]
+            end
+          end
+
+          retention_in_days = @retention_in_days
+          unless @retention_in_days_key.nil?
+            if @remove_retention_in_days_key
+              awstags = record.delete(@retention_in_days_key)
+            else
+              awstags = record[@retention_in_days_key]
+            end
+          end
+
           if @auto_create_stream
-            create_log_group(group_name)
+            create_log_group(group_name, awstags)
+            unless retention_in_days.nil?
+              put_retention_policy(group_name, retention_in_days)
+            end
           else
             log.warn "Log group '#{group_name}' does not exist"
             next
@@ -200,7 +240,7 @@ module Fluent
     end
 
     def store_next_sequence_token(group_name, stream_name, token)
-      @store_next_sequence_token_mutex.synchronize do 
+      @store_next_sequence_token_mutex.synchronize do
         @sequence_tokens[group_name][stream_name] = token
       end
     end
@@ -314,12 +354,23 @@ module Fluent
       store_next_sequence_token(group_name, stream_name, response.next_sequence_token)
     end
 
-    def create_log_group(group_name)
+    def create_log_group(group_name, log_group_aws_tags = nil)
       begin
-        @logs.create_log_group(log_group_name: group_name)
+        @logs.create_log_group(log_group_name: group_name, tags: log_group_aws_tags)
         @sequence_tokens[group_name] = {}
       rescue Aws::CloudWatchLogs::Errors::ResourceAlreadyExistsException
         log.debug "Log group '#{group_name}' already exists"
+      end
+    end
+
+    def put_retention_policy(group_name, retention_in_days)
+      begin
+        @logs.put_retention_policy({
+          log_group_name: group_name,
+          retention_in_days: retention_in_days
+        })
+      rescue Aws::CloudWatchLogs::Errors::InvalidParameterException => error
+        log.warn "failed to set retention policy for Log group '#{group_name}' with error #{error.backtrace}"
       end
     end
 

--- a/test/plugin/test_out_cloudwatch_logs.rb
+++ b/test/plugin/test_out_cloudwatch_logs.rb
@@ -24,6 +24,8 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
       log_group_name test_group
       log_stream_name test_stream
       auto_create_stream false
+      log_group_aws_tags { "tagkey": "tagvalue", "tagkey_2": "tagvalue_2"}
+      retention_in_days 5
     EOC
 
     assert_equal('test_id', d.instance.aws_key_id)
@@ -32,6 +34,9 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
     assert_equal('test_group', d.instance.log_group_name)
     assert_equal('test_stream', d.instance.log_stream_name)
     assert_equal(false, d.instance.auto_create_stream)
+    assert_equal("tagvalue", d.instance.log_group_aws_tags.fetch("tagkey"))
+    assert_equal("tagvalue_2", d.instance.log_group_aws_tags.fetch("tagkey_2"))
+    assert_equal(5, d.instance.retention_in_days)
   end
 
   def test_write
@@ -52,7 +57,7 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
     assert_equal((time.to_i + 1) * 1000, events[1].timestamp)
     assert_equal('{"cloudwatch":"logs2"}', events[1].message)
 
-    assert_match(/Calling PutLogEvents API/, d.instance.log.logs[0])
+    assert_match(/Called PutLogEvents API/, d.instance.log.logs[0])
   end
 
   def test_write_utf8
@@ -270,7 +275,7 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
     d.run
 
     # Call API once for each stream
-    assert_equal(2, d.instance.log.logs.select {|l| l =~ /Calling PutLogEvents API/ }.size)
+    assert_equal(2, d.instance.log.logs.select {|l| l =~ /Called PutLogEvents API/ }.size)
 
     sleep 10
 
@@ -310,6 +315,188 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
     assert_equal({'cloudwatch' => 'logs1', 'message' => 'message1'}, JSON.parse(events[0].message))
   end
 
+  def test_log_group_aws_tags
+    clear_log_group
+
+    d = create_driver(<<-EOC)
+    #{default_config}
+    auto_create_stream true
+    use_tag_as_stream true
+    log_group_name_key group_name_key
+    log_group_aws_tags {"tag1": "value1", "tag2": "value2"}
+    EOC
+
+    records = [
+      {'cloudwatch' => 'logs1', 'message' => 'message1', 'group_name_key' => log_group_name},
+      {'cloudwatch' => 'logs2', 'message' => 'message1', 'group_name_key' => log_group_name},
+      {'cloudwatch' => 'logs3', 'message' => 'message1', 'group_name_key' => log_group_name},
+    ]
+
+    time = Time.now
+    records.each_with_index do |record, i|
+      d.emit(record, time.to_i + i)
+    end
+    d.run
+
+    awstags = get_log_group_tags
+    assert_equal("value1", awstags.fetch("tag1"))
+    assert_equal("value2", awstags.fetch("tag2"))
+  end
+
+  def test_retention_in_days
+    clear_log_group
+
+    d = create_driver(<<-EOC)
+    #{default_config}
+    auto_create_stream true
+    use_tag_as_stream true
+    log_group_name_key group_name_key
+    retention_in_days 7
+    EOC
+
+    records = [
+      {'cloudwatch' => 'logs1', 'message' => 'message1', 'group_name_key' => log_group_name},
+      {'cloudwatch' => 'logs2', 'message' => 'message1', 'group_name_key' => log_group_name},
+      {'cloudwatch' => 'logs3', 'message' => 'message1', 'group_name_key' => log_group_name},
+    ]
+
+    time = Time.now
+    records.each_with_index do |record, i|
+      d.emit(record, time.to_i + i)
+    end
+    d.run
+
+    retention = get_log_group_retention_days
+    assert_equal(d.instance.retention_in_days, retention)
+  end
+
+  def test_invalid_retention_in_days
+    clear_log_group
+
+    d = create_driver(<<-EOC)
+    #{default_config}
+    auto_create_stream true
+    use_tag_as_stream true
+    log_group_name_key group_name_key
+    retention_in_days 4
+    EOC
+
+    records = [
+      {'cloudwatch' => 'logs1', 'message' => 'message1', 'group_name_key' => log_group_name},
+      {'cloudwatch' => 'logs2', 'message' => 'message1', 'group_name_key' => log_group_name},
+      {'cloudwatch' => 'logs3', 'message' => 'message1', 'group_name_key' => log_group_name},
+    ]
+
+    time = Time.now
+    records.each_with_index do |record, i|
+      d.emit(record, time.to_i + i)
+    end
+    d.run
+
+    assert_match(/failed to set retention policy for Log group/, d.instance.log.logs[0])
+  end
+
+  def test_log_group_aws_tags_key
+    clear_log_group
+
+    d = create_driver(<<-EOC)
+    #{default_config}
+    auto_create_stream true
+    use_tag_as_stream true
+    log_group_name_key group_name_key
+    log_group_aws_tags_key aws_tags
+    EOC
+
+    records = [
+      {'cloudwatch' => 'logs1', 'message' => 'message1', 'group_name_key' => log_group_name, 'aws_tags' => {"tag1" => "value1", "tag2" => "value2"}},
+      {'cloudwatch' => 'logs2', 'message' => 'message1', 'group_name_key' => log_group_name, 'aws_tags' => {"tag1" => "value1", "tag2" => "value2"}},
+      {'cloudwatch' => 'logs3', 'message' => 'message1', 'group_name_key' => log_group_name, 'aws_tags' => {"tag1" => "value1", "tag2" => "value2"}}
+    ]
+
+    time = Time.now
+    records.each_with_index do |record, i|
+      d.emit(record, time.to_i + i)
+    end
+    d.run
+
+    awstags = get_log_group_tags
+    assert_equal("value1", awstags.fetch("tag1"))
+    assert_equal("value2", awstags.fetch("tag2"))
+  end
+
+  def test_log_group_aws_tags_key_same_group_diff_tags
+    clear_log_group
+
+    d = create_driver(<<-EOC)
+    #{default_config}
+    auto_create_stream true
+    use_tag_as_stream true
+    log_group_name_key group_name_key
+    log_group_aws_tags_key aws_tags
+    EOC
+
+    records = [
+      {'cloudwatch' => 'logs1', 'message' => 'message1', 'group_name_key' => log_group_name, 'aws_tags' => {"tag1" => "value1", "tag2" => "value2"}},
+      {'cloudwatch' => 'logs3', 'message' => 'message1', 'group_name_key' => log_group_name, 'aws_tags' => {"tag3" => "value3", "tag4" => "value4"}}
+    ]
+
+    time = Time.now
+    records.each_with_index do |record, i|
+      d.emit(record, time.to_i + i)
+    end
+    d.run
+
+    awstags = get_log_group_tags
+    assert_equal("value1", awstags.fetch("tag1"))
+    assert_equal("value2", awstags.fetch("tag2"))
+    assert_raise KeyError do
+      awstags.fetch("tag3")
+    end
+    assert_raise KeyError do
+      awstags.fetch("tag4")
+    end
+  end
+
+  def test_log_group_aws_tags_key_no_tags
+    clear_log_group
+
+    d = create_driver(<<-EOC)
+    #{default_config}
+    auto_create_stream true
+    log_group_name_key group_name_key
+    log_stream_name_key stream_name_key
+    remove_log_group_name_key true
+    remove_log_stream_name_key true
+    log_group_aws_tags_key aws_tags
+    EOC
+
+    stream = log_stream_name
+    records = [
+      {'cloudwatch' => 'logs1', 'message' => 'message1', 'group_name_key' => log_group_name, 'stream_name_key' => stream},
+      {'cloudwatch' => 'logs2', 'message' => 'message2', 'group_name_key' => log_group_name, 'stream_name_key' => stream}
+    ]
+
+    time = Time.now
+    records.each_with_index do |record, i|
+      d.emit(record, time.to_i + i)
+    end
+    d.run
+
+    sleep 10
+
+    awstags = get_log_group_tags
+
+    assert_raise KeyError do
+      awstags.fetch("tag1")
+    end
+
+    events = get_log_events(log_group_name, stream)
+    assert_equal(2, events.size)
+    assert_equal(time.to_i * 1000, events[0].timestamp)
+    assert_equal({'cloudwatch' => 'logs1', 'message' => 'message1'}, JSON.parse(events[0].message))
+    assert_equal({'cloudwatch' => 'logs2', 'message' => 'message2'}, JSON.parse(events[1].message))
+  end
+
   def test_retrying_on_throttling_exception
     resp = mock()
     resp.expects(:next_sequence_token)
@@ -323,10 +510,9 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
     d.emit({'message' => 'message1'}, time.to_i)
     d.run
 
-    assert_match(/Calling PutLogEvents/, d.instance.log.logs[0])
-    assert_match(/failed to PutLogEvents/, d.instance.log.logs[1])
-    assert_match(/Calling PutLogEvents/, d.instance.log.logs[2])
-    assert_match(/retry succeeded/, d.instance.log.logs[3])
+    assert_match(/failed to PutLogEvents/, d.instance.log.logs[0])
+    assert_match(/Called PutLogEvents/, d.instance.log.logs[1])
+    assert_match(/retry succeeded/, d.instance.log.logs[2])
   end
 
   def test_retrying_on_throttling_exception_and_throw_away
@@ -345,12 +531,9 @@ put_log_events_retry_limit 1
     d.emit({'message' => 'message1'}, time.to_i)
     d.run
 
-    assert_match(/Calling PutLogEvents/, d.instance.log.logs[0])
+    assert_match(/failed to PutLogEvents/, d.instance.log.logs[0])
     assert_match(/failed to PutLogEvents/, d.instance.log.logs[1])
-    assert_match(/Calling PutLogEvents/, d.instance.log.logs[2])
-    assert_match(/failed to PutLogEvents/, d.instance.log.logs[3])
-    assert_match(/Calling PutLogEvents/, d.instance.log.logs[4])
-    assert_match(/failed to PutLogEvents and throwing away/, d.instance.log.logs[5])
+    assert_match(/failed to PutLogEvents and discard logs/, d.instance.log.logs[2])
   end
 
   def test_too_large_event

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,6 +43,16 @@ module CloudwatchLogsTestHelper
     @log_stream_name = log_stream_name_prefix ? log_stream_name_prefix + uuid : uuid
   end
 
+  def get_log_group_tags(name = nil)
+    name ||= log_group_name
+    logs.list_tags_log_group(log_group_name: name).tags
+  end
+
+  def get_log_group_retention_days(name = nil)
+    name ||= log_group_name
+    logs.describe_log_groups(log_group_name_prefix: name, limit: 1).log_groups.first.retention_in_days
+  end
+
   def clear_log_group
     [log_group_name, fluentd_tag].each do |name|
       begin


### PR DESCRIPTION
For cost monitoring of the logs, we had a requirement to add tags to the log groups we are creating and also to have expiration on them (default is never expire)

The PR adds support for following:

1. adding awstags for the log groups at time of creation of log groups
2. Adding retention policy at the time of creation of log groups
3. Fix the tests that were failing in test_out_cloudwatch_logs

Kindly review the change and let me know if this looks fine or more changes are needed.

Many thanks in advance
Rajat Jindal